### PR TITLE
Use `GPIO_IN_ADDRESS` instead of `GPIO_OUT_ADDRESS` when reading on `ESP8266`

### DIFF
--- a/src/config_esp8266.h
+++ b/src/config_esp8266.h
@@ -37,7 +37,7 @@ class PinReader  {
 
         /// reads all pins and provides the result as bitmask
         inline PinBitArray readAll() {
-          uint32_t input = (GPIO_REG_READ(GPIO_OUT_ADDRESS) & (uint32)(0b1111111111111111)) >> start_pin;
+          uint32_t input = (GPIO_REG_READ(GPIO_IN_ADDRESS) & (uint32)(0b1111111111111111)) >> start_pin;
           return input;
         }
 


### PR DESCRIPTION
After debugging and reading up on `GPIO_*` I realized that we're
unintentionally using `GPOI_OUT_ADDRESS` here (intended for writing to
pins), and just changed that to `GPIO_IN_ADDRESS`.

I think this has been here from the start, couldn't find any change
where this line was touched at least, so I guess it hasn't ever worked,
but now it works somehow at least. I still get pretty frequent crashes
after/during captures, but now it's at least (barely) usable.

Should fix #10
